### PR TITLE
Remove extra quote in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ grunt.initConfig({
     },
     jar_task: {
       execOptions:{
-        cwd: ""/path/where/jar/command/is/run/"
+        cwd: "/path/where/jar/command/is/run/"
       },
       command: "jar",
       jarName: "my.jar",


### PR DESCRIPTION
An extra quote on line 178 was affecting the syntax highlighting
